### PR TITLE
DRIVERS/VME4LX/DRIVER_K24: add a debug parameter to kernel module

### DIFF
--- a/DRIVERS/VME4LX/DRIVER_K24/vme4l-core.c
+++ b/DRIVERS/VME4LX/DRIVER_K24/vme4l-core.c
@@ -354,6 +354,13 @@ static int major = VME4L_MAJOR;  /**< major device number for /dev/vme4l_xx */
 module_param( major, int, 0664 );
 MODULE_PARM_DESC(major, "VME4L devices major number");
 
+static int debug = DEBUG_DEFAULT;  /**< enable debug printouts */
+
+module_param(debug, int, S_IRUGO | S_IWUSR);
+MODULE_PARM_DESC(debug, "Enable debugging printouts (default " \
+			M_INT_TO_STR(DEBUG_DEFAULT) ")");
+
+
 /*--------------------------------------+
 |   PROTOTYPES                          |
 +--------------------------------------*/
@@ -1915,9 +1922,7 @@ static int vme4l_release(
 	struct file   *file
 )
 {
-#ifdef DBG
 	int minor = MINOR(inode->i_rdev);
-#endif
 	int vector;
 
 	VME4LDBG("vme4l_close %s\n", G_spaceTbl[minor].devName );

--- a/DRIVERS/VME4LX/DRIVER_K24/vme4l-core.h
+++ b/DRIVERS/VME4LX/DRIVER_K24/vme4l-core.h
@@ -134,14 +134,23 @@
 typedef void *VME4L_BRIDGE_HANDLE;
 #endif
 
+#define STR_HELPER(x) #x
+#define M_INT_TO_STR(x) STR_HELPER(x)
+
 #define VME_DBG_PREFIX 	printk
 
 #ifdef DBG
-# define VME4LDBG(fmt, args...) VME_DBG_PREFIX( KERN_DEBUG fmt, ## args )
+#define DEBUG_DEFAULT 1
 #else
-# define VME4LDBG(fmt, args...) do { } while(0);
+#define DEBUG_DEFAULT 0
 #endif
 
+#define VME4LDBG(fmt, args...) \
+	do { \
+		if (debug) { \
+			VME_DBG_PREFIX( KERN_DEBUG fmt, ## args ); \
+		} \
+	} while (0)
 
 /*--------------------------------------+
 |   TYPDEFS                             |

--- a/DRIVERS/VME4LX/DRIVER_K24/vme4l-pldz002-cham.c
+++ b/DRIVERS/VME4LX/DRIVER_K24/vme4l-pldz002-cham.c
@@ -274,6 +274,12 @@ static CHAMELEONV2_DRIVER_T G_driver = {
     .remove   = vme4l_remove
 };
 
+static int debug = DEBUG_DEFAULT;  /**< enable debug printouts */
+
+module_param(debug, int, S_IRUGO | S_IWUSR);
+MODULE_PARM_DESC(debug, "Enable debugging printouts (default " \
+			M_INT_TO_STR(DEBUG_DEFAULT) ")");
+
 /*--------------------------------------+
 |   PROTOTYPES                          |
 +--------------------------------------*/
@@ -646,8 +652,8 @@ static int DmaSetup(
 		}
 		*vmeAddr += sgList->dmaLength;
 	}
-#ifdef DBG
-    {
+
+	if (debug) {
 		int i;
 		bdVaddr = MEN_PLDZ002_DMABD_OFFS;
 		VME4LDBG("DmaBD setup for %s:\n", direction ? "write" : "read" );
@@ -661,7 +667,7 @@ static int DmaSetup(
 			bdVaddr+=0x10;
 		}
 	}
-#endif
+
  CLEANUP:
 	VME4LDBG("<- DmaSetup\n");
 	return rv < 0 ? rv : endBd;
@@ -732,7 +738,7 @@ static int DmaBounceSetup(
 						 PLDZ002_DMABD_DST( PLDZ002_DMABD_DIR_SRAM ) |
 						 bdAm | PLDZ002_DMABD_END );
 	}
-#ifdef DBG
+
 	VME4LDBG("bounce DMA BD setup:\n");
 	VME4LDBG("phys 0x%x virt 0x%08x = 0x%08x",
 			 h->bounce.phys + bdOff+0x0, h->bounce.vaddr + bdOff+0x0, VME_REG_DMABD_RD32(bdOff+0x0));
@@ -742,7 +748,6 @@ static int DmaBounceSetup(
 			 h->bounce.phys + bdOff+0x8, h->bounce.vaddr + bdOff+0x8, VME_REG_DMABD_RD32(bdOff+0x8));
 	VME4LDBG("phys 0x%x virt 0x%08x = 0x%08x",
 			 h->bounce.phys + bdOff+0xc, h->bounce.vaddr + bdOff+0xc, VME_REG_DMABD_RD32(bdOff+0xc));
-#endif
 
  CLEANUP:
 	*bounceBufP = h->bounce.vaddr;


### PR DESCRIPTION
Add a "debug" parameter to the vme4l-core and me4l-pldz002-cham kernel
modules. The debug information can be on or off by setting this
parameter (even after load of a kernel module). The use of ALL_DBGS affects
the default debug setting.

Signed-off-by: Adam Wujek <adam.wujek@cern.ch>