### PR TITLE
Port mdis to kernel 4.15

### DIFF
--- a/DRIVERS/A21_MSI/a21_msi_enable.c
+++ b/DRIVERS/A21_MSI/a21_msi_enable.c
@@ -28,6 +28,8 @@
 #include <linux/module.h>
 #include <linux/init.h>
 #include <linux/pci.h>
+#include <linux/msi.h>
+#include <linux/version.h>
 
 #define A21_MSI_BLOCK_SIZE    32 
 
@@ -61,6 +63,7 @@ EXPORT_SYMBOL(A21_MSI_enable);
 int mod_init(void)
 {
 	struct pci_dev *pdev = NULL;
+	struct msix_entry *entries = NULL;
 	int error;
 	int nvec;
 	printk( KERN_INFO "MEN " COMP_NAME " init_module.\n");
@@ -85,11 +88,19 @@ int mod_init(void)
 	pci_set_master(pdev);
 
 	if ( pci_msi_enabled()) {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3,16,0)
 	  if((nvec = pci_enable_msi_block(pdev, A21_MSI_BLOCK_SIZE ))) {
 	    if (pci_enable_msi_block(pdev, nvec) < 0) {
 	      printk(KERN_ERR " *** failed to request MSI, falling back to legacy IRQs\n");
 	    }
 	  }
+#else
+	  if((nvec = pci_enable_msix_exact(pdev, entries, A21_MSI_BLOCK_SIZE ))) {
+	    if (pci_enable_msix_exact(pdev, entries, nvec) < 0) {
+	      printk(KERN_ERR " *** failed to request MSI, falling back to legacy IRQs\n");
+	    }
+	  }
+#endif
 	}
 	printk( KERN_INFO "MSIs enabled successfully.\n");
 out:

--- a/DRIVERS/VME_16Z002/vme4l-core.c
+++ b/DRIVERS/VME_16Z002/vme4l-core.c
@@ -1104,7 +1104,11 @@ static int vme4l_start_wait_dma(void)
 	int rv;
 	uint32_t ticks = 5 * HZ;
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0)
 	wait_queue_t __wait;
+#else
+	wait_queue_entry_t __wait;
+#endif
 
 	/* Add to wait queue before starting DMA */
 	init_waitqueue_entry(&__wait, current);

--- a/DRIVERS/VME_16Z002/vme4l-core.h
+++ b/DRIVERS/VME_16Z002/vme4l-core.h
@@ -112,7 +112,11 @@
 #include <linux/mm.h>
 #include <linux/pci.h>
 #include <linux/seq_file.h>
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,12,0)
 #include <asm/uaccess.h>        /* put_user */
+#else
+#include <linux/uaccess.h>        /* put_user */
+#endif
 #include <asm/io.h>
 
 /* include men_vme_kernelif.h depending on build environment */

--- a/INCLUDE/NATIVE/MEN/MACCESS/mac_linux_generic.h
+++ b/INCLUDE/NATIVE/MEN/MACCESS/mac_linux_generic.h
@@ -56,6 +56,9 @@
 # define _MAC_OFF_	0			
 #endif
 
+#ifdef __KERNEL__
+# include <asm/io.h>
+#endif
 
 /*---- MEMORY MAPPED I/O ---*/
 #ifdef MAC_MEM_MAPPED

--- a/LIBSRC/MDIS_KERNEL/mk_intern.h
+++ b/LIBSRC/MDIS_KERNEL/mk_intern.h
@@ -120,7 +120,11 @@
 #include <linux/interrupt.h>
 
 #include <asm/fixmap.h>     /* fix_to_virt() */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0)
 #include <asm/uaccess.h>     /* copy_to/from_user */
+#else
+#include <linux/uaccess.h>     /* copy_to/from_user */
+#endif
 
 
 #include <MEN/men_typs.h>

--- a/LIBSRC/OSS/oss_sem.c
+++ b/LIBSRC/OSS/oss_sem.c
@@ -237,7 +237,11 @@ int32 OSS_SemWait(
 
 	/* sem->lock is locked here */
 	{
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0)
 		wait_queue_t __wait;
+#else
+		wait_queue_entry_t __wait;
+#endif
 		init_waitqueue_entry(&__wait, current);	
 
 		add_wait_queue( &sem->wq, &__wait);


### PR DESCRIPTION
Replace pci_enable_msi_block with pci_enable_msix_exact
Fix incompatible casting
Replace init_timer with timer_setup
Use <linux/uaccess.h> instead of <asm/uaccess.h>
Do not print __DATE__ and __TIME__
Use type wait_queue_entry_t instead of wait_queue_t
Unify definition of DmaSetup
Remove duplicated definition: debug = DEBUG_DEFAULT
Function check_mem_region is dropped in new kernel
Unify definition of Tsi148_DmaSetup
Do not print GIT_VERSION

Signed-off-by: Xu, Yi <Yi.Xu@men.de>