### PR TITLE
Fix compilation of vme4l driver

### DIFF
--- a/MDISforLinux/DRIVERS/VME_16Z002/vme4l-core.c
+++ b/MDISforLinux/DRIVERS/VME_16Z002/vme4l-core.c
@@ -1013,7 +1013,7 @@ static int vme4l_start_wait_dma(void)
 	int rv;
 	uint32_t ticks = 5 * HZ;
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,13,0)
 	wait_queue_t __wait;
 #else
 	wait_queue_entry_t __wait;

--- a/MDISforLinux/DRIVERS/VME_16Z002/vme4l-pldz002.c
+++ b/MDISforLinux/DRIVERS/VME_16Z002/vme4l-pldz002.c
@@ -509,9 +509,6 @@ static int DmaSetup(
 	int direction,
 	int swapMode,
 	vmeaddr_t *vmeAddr,
-	dma_addr_t *dmaAddr,
-	int *dmaLeft,
-	int vme_block_size,
 	int flags)
 {
 	int alignVme=4, sg, rv=0, endBd;

--- a/MDISforLinux/DRIVERS/VME_16Z002/vme4l-tsi148.c
+++ b/MDISforLinux/DRIVERS/VME_16Z002/vme4l-tsi148.c
@@ -1844,9 +1844,6 @@ static int Tsi148_DmaSetup(
 	int direction,
 	int swapMode,
 	vmeaddr_t *vmeAddr,
-	dma_addr_t *dmaAddr,
-	int *dmaLeft,
-	int vme_block_size,
 	int flags)
 {
 	int i;

--- a/MDISforLinux/LIBSRC/MDIS_KERNEL/mk_intern.h
+++ b/MDISforLinux/LIBSRC/MDIS_KERNEL/mk_intern.h
@@ -42,7 +42,7 @@
 #include <linux/interrupt.h>
 
 #include <asm/fixmap.h>     /* fix_to_virt() */
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,10,0)
 #include <asm/uaccess.h>     /* copy_to/from_user */
 #else
 #include <linux/uaccess.h>     /* copy_to/from_user */

--- a/MDISforLinux/LIBSRC/MDIS_KERNEL/mk_intern.h
+++ b/MDISforLinux/LIBSRC/MDIS_KERNEL/mk_intern.h
@@ -120,7 +120,7 @@
 #include <linux/interrupt.h>
 
 #include <asm/fixmap.h>     /* fix_to_virt() */
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,10,0)
 #include <asm/uaccess.h>     /* copy_to/from_user */
 #else
 #include <linux/uaccess.h>     /* copy_to/from_user */

--- a/MDISforLinux/LIBSRC/OSS/oss_sem.c
+++ b/MDISforLinux/LIBSRC/OSS/oss_sem.c
@@ -217,7 +217,7 @@ int32 OSS_SemWait(
 
 	/* sem->lock is locked here */
 	{
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,13,0)
 		wait_queue_t __wait;
 #else
 		wait_queue_entry_t __wait;

--- a/MDISforLinux/LIBSRC/OSS/oss_sem.c
+++ b/MDISforLinux/LIBSRC/OSS/oss_sem.c
@@ -237,7 +237,7 @@ int32 OSS_SemWait(
 
 	/* sem->lock is locked here */
 	{
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,13,0)
 		wait_queue_t __wait;
 #else
 		wait_queue_entry_t __wait;


### PR DESCRIPTION
In issue #11 there were changes introduced that lead to compile errors in VME for Linux driver.
Apparently nobody ever tried to build that, let alone testing the changes ...
I had a look at the changes done back then and found the problematic part in dmaSetup method implementations to be unnecessary: none of the extra parameters deviating from the prototype is used.
So even done without knowing the cause to change this function prototype in the first place, my changes should do no (extra) harm.
Additional calamity might arise once I get to testing that stuff ... ;-/

Edit: I should have noted that also the latest stable release contains this problem and my changes also apply well on those sources.