### PR TITLE
Fix MDIS compilation for kernel versions 4.10 to 4.14

### DIFF
--- a/MDISforLinux/LIBSRC/MDIS_KERNEL/mk_intern.h
+++ b/MDISforLinux/LIBSRC/MDIS_KERNEL/mk_intern.h
@@ -120,7 +120,7 @@
 #include <linux/interrupt.h>
 
 #include <asm/fixmap.h>     /* fix_to_virt() */
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,10,0)
 #include <asm/uaccess.h>     /* copy_to/from_user */
 #else
 #include <linux/uaccess.h>     /* copy_to/from_user */

--- a/MDISforLinux/LIBSRC/OSS/oss_sem.c
+++ b/MDISforLinux/LIBSRC/OSS/oss_sem.c
@@ -237,7 +237,7 @@ int32 OSS_SemWait(
 
 	/* sem->lock is locked here */
 	{
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,13,0)
 		wait_queue_t __wait;
 #else
 		wait_queue_entry_t __wait;


### PR DESCRIPTION
Some conditional compilations depended on wrong Linux version preventing MDIS from getting compiled for (at least) 4.10 up to and including 4.14.
This covers one include of uaccess.h in mk_intern.h and one wait queue use in oss_sem.c.