### PR TITLE
Fix exit value of vme4l_mtest

### DIFF
--- a/MDISforLinux/TOOLS/VME4L_API/VME4L_MTEST/vme4l_mtest.c
+++ b/MDISforLinux/TOOLS/VME4L_API/VME4L_MTEST/vme4l_mtest.c
@@ -53,6 +53,7 @@
 	 printf("\n*** Error during: %s\nfile %s\nline %d\n", \
       #expression,__FILE__,__LINE__);\
       printf("%s\n",strerror(errno));\
+     tot_errors++;\
      goto ABORT;\
  }
 
@@ -715,6 +716,6 @@ int main( int argc, char *argv[] )
  ABORT:
 
 	show_test_result();
-	return 0;
+	return tot_errors;
 }
 


### PR DESCRIPTION
Wanted to use vme4l_mtest in environmental tests of A025 (against A021C) and found out that the exit value is wrong under certain circumstances.
I found out that a macro is used for general function abortion (CHK()) which doesn't touch the global error counter "tot_errors".
The latter, however, is used for exit value, so if the only error in program is triggered by that macro, for the calling process it seems that everything went ok - bummer!
Also I didn't understand why 'tot_errors' isn't used at all for return value in main() ...
