### PR TITLE
VME4L: add automatic device node handling

### DIFF
--- a/MDISforLinux/DRIVERS/VME_16Z002/vme4l-core.h
+++ b/MDISforLinux/DRIVERS/VME_16Z002/vme4l-core.h
@@ -675,6 +675,7 @@ typedef struct {
 	vmeaddr_t spcEnd;			/**< VME end addr of this space  */
 	int maxWidth;				/**< max accessWidth  */
 	struct list_head lstAdrsWins; /**< list of address windows  */
+	struct device *dev;			/**< devfs node  */
 } VME4L_SPACE_ENT;
 
 


### PR DESCRIPTION
VME for Linux driver didn't handle device files automatically, instead these had to be created manually.

This change adds automatic creation and deletion of all supported devices during module initialization and cleanup, respectively.