### PR TITLE
add version info to kernel modules

### DIFF
--- a/MDISforLinux/DRIVERS/MDIS_LL/NATIVE/ll_module.c
+++ b/MDISforLinux/DRIVERS/MDIS_LL/NATIVE/ll_module.c
@@ -117,5 +117,10 @@ void cleanup_module(void)
 MODULE_DESCRIPTION( COMP_NAME " MDIS low level driver");
 MODULE_AUTHOR("Klaus Popp <klaus.popp@men.de>");
 #ifdef MODULE_LICENSE
-MODULE_LICENSE("GPL");
+    MODULE_LICENSE("GPL");
 #endif
+
+#ifdef MAK_REVISION
+    MODULE_VERSION(MENT_XSTR(MAK_REVISION));
+#endif
+


### PR DESCRIPTION
Belongs to MEN-Mikro-Elektronik/13MD05-90#94
The dp_fixrevs branch adds version info to kernel modules.
The details are described in issue #94.