### PR TITLE
fix access_ok usage for kernel=>5.0.0

### DIFF
--- a/MDISforLinux/LIBSRC/MDIS_KERNEL/mk_module.c
+++ b/MDISforLinux/LIBSRC/MDIS_KERNEL/mk_module.c
@@ -233,10 +233,14 @@ int mk_ioctl (
 	* access_ok is kernel-oriented, so the concept of "read" and
 	* "write" is reversed
 	*/
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,0,0)
+	err = !access_ok((void *)arg, size);
+#else
 	if (_IOC_DIR(cmd) & _IOC_READ)
 		err = !access_ok(VERIFY_WRITE, (void *)arg, size);
 	else if (_IOC_DIR(cmd) & _IOC_WRITE)
 		err =  !access_ok(VERIFY_READ, (void *)arg, size);
+#endif
 
 	if (err)
 		return -EFAULT;	


### PR DESCRIPTION
Tested with Linux vm-manjaro 5.2.2-1-MANJARO #1 SMP PREEMPT Sun Jul 21 12:53:04 UTC 2019 x86_64 GNU/Linux.
