### PR TITLE
update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,21 @@
-# 13MD05-90
+# 13MD05-90 - MDIS5 System Package for Linux
 
-This repository represents the complete MEN MDIS for Linux System Package plus lowlevel drivers.
+This is the base repository of the MDIS5 System Package for Linux. It includes some other repositories as submodules.
+The 13MD05-90 MDIS5 system package includes most standard device drivers for Linux available from MEN.
 
-MDIS, the MEN Driver Interface System, is a framework to develop device drivers for almost any kind of I/O hardware. A properly written driver runs on all operating systems supported by MDIS. Operating systems currently supported include Windows, VxWorks and Linux.
+MDIS, the MEN Driver Interface System, is a framework to develop device drivers for almost any kind of I/O hardware. A properly written driver runs on all operating systems supported by MDIS. Operating systems currently supported include Linux, Windows, VxWorks and QNX (MDIS4 only).
+
+## Supported Components
+
+For detailed information about supported Linux versions and hardware components of the current release, please refer to *supported_components.md* of this repository.
 
 ## Official Release and Documentation
+
 For the latest official released version, please visit the MEN website https://www.men.de/software/13md05-90  
 There you can also download the MDIS Documentation.
 
+The 13MD05-90 MDIS5 system package contains the *QUICKSTART.md* Quick Start Guide. You can use it as a cheat sheet to set up MDIS for Linux, but it doesn't provide any background information on MDIS. For comprehensive information, please refer to the MDIS User Manual for Linux (*21md05-90.pdf*).
 
 ## Installation
 
-Run the '**INSTALL.sh**' script to copy the files to the default location **/opt/menlinux/** or pass another folder name to the script.
+Run the *INSTALL.sh* script to copy the files to the default location **/opt/menlinux/** or pass another folder name to the script.


### PR DESCRIPTION
Please merge it for 13MD05-90_02_01 if possible and consider this:

I found the following problem:
README.md doesn't list the tested Linux distributions and kernel versions, as required according MEN_13MD05-90_SA_0290.
BUT: It makes no sense to add this information in the readme, because supported_components.md lists already the Linux distros.
==>
- I will change SA_0290 for next release.
- Please use the updated README.md of this pull request for 02.01
- Please add the kernel versions to supported_components.md (I will make a comment to SA_0355 for this)
With this approach, we can keep the README.md release independent whereas supported_components.md and 13MD05-90_changelog.md is release specific.
