### PR TITLE
fix MDIS_KERNEL for CentOS 8.0

### DIFF
--- a/MDISforLinux/LIBSRC/MDIS_KERNEL/mk_module.c
+++ b/MDISforLinux/LIBSRC/MDIS_KERNEL/mk_module.c
@@ -234,8 +234,11 @@ int mk_ioctl (
 	* access_ok is kernel-oriented, so the concept of "read" and
 	* "write" is reversed
 	*/
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,0,0))
+/*
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,0,0)) || \
     (LINUX_VERSION_CODE >= KERNEL_VERSION(4,18,0) && defined(RHEL_RELEASE))
+*/
 	err = !access_ok((void *)arg, size);
 #else
 	if (_IOC_DIR(cmd) & _IOC_READ)


### PR DESCRIPTION
MDISforLinux/LIBSRC/MDIS_KERNEL/mk_module.c dosn't compile under CentOS 8.0 with kernel:
Linux centos 4.18.0-80.11.2.el8_0.x86_64 #1 SMP Tue Sep 24 11:32:19 UTC 2019 x86_64 x86_64 x86_64 GNU/Linux

```
  CC [M]  /root/mdis/mproj_wizscan/OBJ/nodbg/men_mdis_kernel/mk_module.o
/root/mdis/mproj_wizscan/OBJ/nodbg/men_mdis_kernel/mk_module.c: In function ‘mk_ioctl’:
/root/mdis/mproj_wizscan/OBJ/nodbg/men_mdis_kernel/mk_module.c:239:36: error: macro "access_ok" requires 3 arguments, but only 2 given
  err = !access_ok((void *)arg, size);
                                    ^
/root/mdis/mproj_wizscan/OBJ/nodbg/men_mdis_kernel/mk_module.c:239:9: error: ‘access_ok’ undeclared (first use in this function)
  err = !access_ok((void *)arg, size);
         ^~~~~~~~~
/root/mdis/mproj_wizscan/OBJ/nodbg/men_mdis_kernel/mk_module.c:239:9: note: each undeclared identifier is reported only once for each function it appears in
/root/mdis/mproj_wizscan/OBJ/nodbg/men_mdis_kernel/mk_module.c:218:18: warning: unused variable ‘size’ [-Wunused-variable]
     int err = 0, size = _IOC_SIZE(cmd); /* the size bitfield in cmd */
                  ^~~~
make[4]: *** [scripts/Makefile.build:316: /root/mdis/mproj_wizscan/OBJ/nodbg/men_mdis_kernel/mk_module.o] Error 1
make[3]: *** [scripts/Makefile.build:556: /root/mdis/mproj_wizscan/OBJ/nodbg/men_mdis_kernel] Error 2
make[2]: *** [Makefile:1528: _module_/root/mdis/mproj_wizscan/OBJ] Error 2
make[1]: *** [/opt/menlinux/BUILD/MDIS/TPL/rules.mak:502: callkernelbuild] Error 2
make: *** [/opt/menlinux/BUILD/MDIS/TPL/rules.mak:401: nodbg] Error 2
```

CentOS 8.0 is not a strict requirement for 13MD05-90_02_03, however, the compilation must not fail. Some customer may have this distro still running. In future, we will add the requirement to do a basic compilation test with previous required distros.

I assume that a CentOS 4.18.0 kernel fix changed the behavior. There was an explicit ifdef to handle this CentOS kernel version but this produces now the error in my system. Please evaluate my change and remove or modify the out-commented ifdef.  

Please wait to provide us a new 13MD05-90_02_03_b3 package. I detected other problems that have to be fixed. I will continue testing and give you a test report about failed acceptance test.