### PR TITLE
Update vme4l-core.c

### DIFF
--- a/MDISforLinux/DRIVERS/VME_16Z002/vme4l-core.c
+++ b/MDISforLinux/DRIVERS/VME_16Z002/vme4l-core.c
@@ -1255,7 +1255,7 @@ static int vme4l_zc_dma( VME4L_SPACE spc, VME4L_RW_BLOCK *blk, int swapMode )
 
 	if (to_user) {
 		VME4LDBG("To/from Userspace DMA transfer\n");
-		rv = get_user_pages_fast( uaddr, nr_pages, direction, pages);
+		rv = get_user_pages_fast( uaddr, nr_pages, direction == DMA_FROM_DEVICE  ? FOLL_WRITE : 0, pages);
 		if (rv < 0)
 			printk(KERN_ERR_PFX "%s: get_user_pages_fast failed rv"
 			       "%d nr pages %d\n",


### PR DESCRIPTION
If the vme4l_core issues a DMA-Transfer to userspace a general protection faultarises due to a wrong flag setup in get_user_pages_fast().


![grafik](https://user-images.githubusercontent.com/105431736/168069618-450d66f8-257d-44f4-91b9-d5c4200bb76b.png)

With:
`rv = get_user_pages_fast( uaddr, nr_pages, direction == DMA_FROM_DEVICE  ? FOLL_WRITE : 0, pages);`

General protection fault doesn't ocurr

![grafik](https://user-images.githubusercontent.com/105431736/168071434-4061f166-0ea8-40a1-bc91-34b08039c08c.png)