### PR TITLE
Update men_chameleon.c

### DIFF
--- a/MDISforLinux/DRIVERS/CHAMELEON/men_chameleon.c
+++ b/MDISforLinux/DRIVERS/CHAMELEON/men_chameleon.c
@@ -698,6 +698,7 @@ static int __devinit pci_init_one(struct pci_dev *pdev,
 	for ( i=0; i < NR_CHAM_TBL_ATTRS; i++) {
 		CHAM_ATTR_SET(h->attr_cham[i],G_sysChamTblAttrname[i],CHAM_SYSFS_MODE,cham_sysfs_read,NULL);
 		h->chamTblAttrs[i] = &h->attr_cham[i].attr;
+		sysfs_attr_init(&h->attr_cham[i].attr);
 	}
 	h->chamTblAttrGrp.attrs = h->chamTblAttrs;
 
@@ -781,6 +782,7 @@ static int __devinit pci_init_one(struct pci_dev *pdev,
 		for ( i=0; i < NR_CHAM_IPCORE_ATTRS; i++) {
 			CHAM_ATTR_SET(ip->attr_ip[i], G_sysIpCoreAttrname[i],CHAM_SYSFS_MODE,cham_sysfs_read,NULL);
 			ip->ipCoreAttrs[i] = &ip->attr_ip[i].attr;
+			sysfs_attr_init(&ip->attr_ip[i].attr);
 		}
 		ip->ipCoreAttrGrp.attrs = ip->ipCoreAttrs;
 


### PR DESCRIPTION
Missing initialisation of sysfs attributes combined with enabled lockdep results in kernel warning

`
[  117.449996] ------------[ cut here ]------------
[  117.450336] DEBUG_LOCKS_WARN_ON(1)
[  117.450357] WARNING: CPU: 0 PID: 1229 at kernel/locking/lockdep.c:3865 lockdep_init_map+0x14f/0x1d0
[  117.451126] Modules linked in: men_lx_chameleon(O+) men_chameleon_io(O) men_chameleon(O) men_oss(O) men_dbg(O) input_leds led_class intel_telemetry_pltdrv intel_punit_ipc intel_telemetry_core pnd2_edac x86_pkg_temp_thermal pcspkr intel_xhci_usb_role_switch roles i915 video backlight
[  117.452648] CPU: 0 PID: 1229 Comm: modprobe Tainted: G           O      5.4.212 #1
[  117.453117] Hardware name: MEN GmbH APL-Platform/MEN F026L06, BIOS 5.12 02/25/2021
[  117.453589] RIP: 0010:lockdep_init_map+0x14f/0x1d0
[  117.453888] Code: e8 f6 13 3e 00 85 c0 74 80 8b 3d 1c 6f 8b 01 85 ff 0f 85 72 ff ff ff 48 c7 c6 dd 31 5a a5 48 c7 c7 24 e8 55 a5 e8 57 8e bf 00 <0f> 0b e9 58 ff ff ff e8 c5 13 3e 00 85 c0 74 21 44 8b 1d ea 6e 8b
[  117.455027] RSP: 0018:ffffb5994065f870 EFLAGS: 00010282
[  117.455360] RAX: 0000000000000000 RBX: 0000000000000000 RCX: 0000000000000000
[  117.455795] RDX: ffffffffa41660c3 RSI: ffffffffa41662af RDI: ffffffffa41660d7
[  117.456223] RBP: ffffb5994065f890 R08: ffffffffa666ccc0 R09: 0000000000000016
[  117.456654] R10: ffffffffa666d0a0 R11: 00000000a666ccd3 R12: ffff903077bace78
[  117.457085] R13: ffff903061318870 R14: 0000000000000000 R15: ffff903061318938
[  117.457529] FS:  00007fae545be740(0000) GS:ffff90307ba00000(0000) knlGS:0000000000000000
[  117.458032] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
[  117.458391] CR2: 00007fd33785b008 CR3: 0000000169240000 CR4: 00000000003406f0
[  117.458817] Call Trace:
[  117.458979]  __kernfs_create_file+0x73/0x100
[  117.459258]  sysfs_add_file_mode_ns+0xa8/0x1a0
[  117.459545]  internal_create_group+0x115/0x370
[  117.459830]  sysfs_create_group+0x13/0x20
[  117.460082]  pci_init_one.cold+0x30c/0x736 [men_lx_chameleon]
[  117.460444]  ? _raw_spin_unlock_irqrestore+0x49/0x50
[  117.460753]  ? lockdep_hardirqs_on+0xf6/0x190
[  117.461033]  ? _raw_spin_unlock_irqrestore+0x49/0x50
[  117.461342]  ? trace_hardirqs_on+0x4c/0x100
[  117.461621]  local_pci_probe+0x48/0x80
[  117.461870]  pci_device_probe+0xdd/0x160
[  117.462122]  really_probe+0xeb/0x3c0
[  117.462352]  driver_probe_device+0xbc/0x100
[  117.462616]  device_driver_attach+0x5d/0x70
[  117.462885]  __driver_attach+0x91/0x160
[  117.463129]  ? device_driver_attach+0x70/0x70
[  117.463410]  bus_for_each_dev+0x81/0xc0
[  117.463662]  driver_attach+0x1e/0x20
[  117.463893]  bus_add_driver+0x164/0x200
[  117.464148]  driver_register+0x74/0xd0
[  117.464395]  ? pci_init_one+0xa0/0xa0 [men_lx_chameleon]
[  117.464730]  __pci_register_driver+0x6e/0x80
[  117.465009]  men_chameleon_init.cold+0x26/0x4a [men_lx_chameleon]
[  117.465392]  do_one_initcall+0x61/0x2f0
[  117.465641]  ? do_init_module+0x28/0x240
[  117.465886]  ? rcu_read_lock_sched_held+0x4f/0x80
[  117.466188]  ? kmem_cache_alloc_trace+0x24e/0x280
[  117.466490]  do_init_module+0x52/0x240
[  117.466727]  load_module+0x27ad/0x2a80
[  117.466996]  __do_sys_finit_module+0xbe/0x120
[  117.467262]  ? __do_sys_finit_module+0xbe/0x120
[  117.467564]  __x64_sys_finit_module+0x1a/0x20
[  117.467835]  do_syscall_64+0x55/0x1b0
[  117.468074]  entry_SYSCALL_64_after_hwframe+0x49/0xbe
[  117.468395] RIP: 0033:0x7fae546b4c99
[  117.468624] Code: 00 c3 66 2e 0f 1f 84 00 00 00 00 00 0f 1f 44 00 00 48 89 f8 48 89 f7 48 89 d6 48 89 ca 4d 89 c2 4d 89 c8 4c 8b 4c 24 08 0f 05 <48> 3d 01 f0 ff ff 73 01 c3 48 8b 0d c7 21 0c 00 f7 d8 64 89 01 48
[  117.469750] RSP: 002b:00007ffdc9fe5278 EFLAGS: 00000246 ORIG_RAX: 0000000000000139
[  117.470214] RAX: ffffffffffffffda RBX: 000055b9c8ad7b60 RCX: 00007fae546b4c99
[  117.470639] RDX: 0000000000000000 RSI: 000055b9c7f94360 RDI: 0000000000000004
[  117.471082] RBP: 0000000000040000 R08: 0000000000000000 R09: 000055b9c8ad7b60
[  117.471511] R10: 0000000000000004 R11: 0000000000000246 R12: 000055b9c7f94360
[  117.471953] R13: 0000000000000000 R14: 0000000000000000 R15: 000055b9c8ad7930
[  117.472405] irq event stamp: 5613
[  117.472623] hardirqs last  enabled at (5613): [<ffffffffa4164b76>] console_unlock+0x466/0x5c0
[  117.473130] hardirqs last disabled at (5612): [<ffffffffa416479d>] console_unlock+0x8d/0x5c0
[  117.473646] softirqs last  enabled at (5532): [<ffffffffa500032c>] __do_softirq+0x32c/0x429
[  117.474156] softirqs last disabled at (5519): [<ffffffffa40f9ff8>] irq_exit+0xb8/0xc0
[  117.474644] ---[ end trace 487ddb78509835fd ]---

`

![grafik](https://user-images.githubusercontent.com/105431736/195595557-568a7e0c-6b44-4589-a5ae-002ced645eca.png)

![grafik](https://user-images.githubusercontent.com/105431736/195596229-d62e42ea-e328-4b95-a023-86941c10bd29.png)
