### PR TITLE
Remove kernel headers prepare commands for CentOS doc

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -100,14 +100,6 @@ Note: RedHat Linux is not officially supported!
 
     ``# ln -s /usr/src/kernels/$(uname -r) /usr/src/linux``
 
-- Prepare the kernel headers:
-
-  ```
-  # cd /usr/src/linux
-  # make oldconfig
-  # make prepare
-  ```
-
 ### Manjaro / Arch Linux
 
 Note: Manjaro/Arch Linux is not officially supported!


### PR DESCRIPTION
The Linux Headers package tha comes with
`yum install kernel-devel` is already prepared
and ready to compile kernel modules against it. No need for extra steps.