### PR TITLE
Pull Request for fixing the awk warnings during the MDIS compation with gawk version >= 5.0.0

### DIFF
--- a/MDISforLinux/BUILD/MDIS/TPL/component.mak
+++ b/MDISforLinux/BUILD/MDIS/TPL/component.mak
@@ -134,7 +134,7 @@ endif
 
 # check if we have a 64bit system
 LONG_WIDTH = $(shell $(CC) $(TPL_DIR)/checkTypeSize.c 2>&1 \
-	          | awk '/\#error/ {print $$NF}')
+	          | sed -n 's/^.*\#error[[:space:]]//p')
 
 ifeq ($(LONG_WIDTH),_64)	
   DEF += -D_LIN64

--- a/MDISforLinux/BUILD/MDIS/TPL/endian.mak
+++ b/MDISforLinux/BUILD/MDIS/TPL/endian.mak
@@ -27,7 +27,7 @@ ifdef KERNEL_CC
  export HOST_OS = $(shell uname -s | awk '{print toupper(substr($$NF,1,5))}')
 
  export TARGET_BYTEORDER = $(shell $(CC) $(TPL_DIR)/gettargetbyteorder.c 2>&1 \
-	| awk '/\#error/ {print $$NF}')
+	| sed -n 's/^.*\#error[[:space:]]//p')
 #$(warning - HOST_OS = $(HOST_OS) ----)
   ifeq ($(HOST_OS),LINUX)
    ifeq ($(TARGET_BYTEORDER),little)

--- a/MDISforLinux/BUILD/MDIS/TPL/usrlib_shared.mak
+++ b/MDISforLinux/BUILD/MDIS/TPL/usrlib_shared.mak
@@ -103,7 +103,7 @@ endif
 
 # check if we have a 64bit system
 LONG_WIDTH = $(shell $(CC) $(TPL_DIR)/checkTypeSize.c 2>&1 \
-	          | awk '/\#error/ {print $$NF}')
+	          | sed -n 's/^.*\#error[[:space:]]//p')
 
 ifeq ($(LONG_WIDTH),_64)	
   DEF += -D_LIN64

--- a/MDISforLinux/BUILD/MDIS/TPL/usrlib_static.mak
+++ b/MDISforLinux/BUILD/MDIS/TPL/usrlib_static.mak
@@ -114,7 +114,7 @@ endif
 
 # check if we have a 64bit system
 LONG_WIDTH = $(shell $(CC) $(TPL_DIR)/checkTypeSize.c 2>&1 \
-	          | awk '/\#error/ {print $$NF}')
+	          | sed -n 's/^.*\#error[[:space:]]//p')
 
 ifeq ($(LONG_WIDTH),_64)	
   DEF += -D_LIN64

--- a/MDISforLinux/BUILD/MDIS/TPL/usrprog_shared.mak
+++ b/MDISforLinux/BUILD/MDIS/TPL/usrprog_shared.mak
@@ -110,7 +110,7 @@ endif
 
 # check if we have a 64bit system
 LONG_WIDTH = $(shell $(CC) $(TPL_DIR)/checkTypeSize.c 2>&1 \
-	          | awk '/\#error/ {print $$NF}')
+	          | sed -n 's/^.*\#error[[:space:]]//p')
 
 ifeq ($(LONG_WIDTH),_64)	
   DEF += -D_LIN64

--- a/MDISforLinux/BUILD/MDIS/TPL/usrprog_static.mak
+++ b/MDISforLinux/BUILD/MDIS/TPL/usrprog_static.mak
@@ -115,7 +115,7 @@ endif
 
 # check if we have a 64bit system
 LONG_WIDTH = $(shell $(CC) $(TPL_DIR)/checkTypeSize.c 2>&1 \
-	          | awk '/\#error/ {print $$NF}')
+	          | sed -n 's/^.*\#error[[:space:]]//p')
 
 ifeq ($(LONG_WIDTH),_64)	
   DEF += -D_LIN64


### PR DESCRIPTION
As reported in #258 it seems to be some incompatibilities with gawk for versions >= 5.0.0. as the scape character \# (and others) is not supported.

The newer Linux distributions ship gawk binaries with versions greater than 5.0.0 so we have decided to replace the awk command with a sed command that works in the same way.

We have tested the new sed command in the following Linux distributions:

- Ubuntu 22.04
- Ubuntu 18.04
- Centos 7

And in all of them the command works properly and MDIS is compiled properly as well.
