### PR TITLE
Detect installation prefix in scan_system script

### DIFF
--- a/MDISforLinux/BUILD/MDIS/TPL/DSC/Makefile.tpl
+++ b/MDISforLinux/BUILD/MDIS/TPL/DSC/Makefile.tpl
@@ -67,7 +67,7 @@ MODS_INSTALL_DIR = /lib/modules/$(LINUX_VERSION)/misc
 # installed. Often something like /usr/local/bin. (relative to
 # the target's root tree)
 ##REPLNEWLINE021
-BIN_INSTALL_DIR = /usr/local/bin
+BIN_INSTALL_DIR = SCAN_BIN_INSTALL_DIR
 ##REPLNEWLINE022
 # The directory in which the shared (.so) user mode libraries
 # are to be installed. Often something like /usr/local/lib.

--- a/MDISforLinux/scan_system.sh
+++ b/MDISforLinux/scan_system.sh
@@ -1423,15 +1423,25 @@ create_makefile () {
     # Add cretion note into Makefile
     sed -i "s/CREATION_NOTE/ ${CREATION_NOTE}\n# ${COMMIT_ID}\n# ${DATE}/g" ${TMP_MAKE_FILE}
 
-    # write library installation directory
-    local LIB_INSTALL_DIR="/usr/local/lib"
-    local LIN_DISTRO_NAME
-    LIN_DISTRO_NAME="$(grep -oPs "(?<=^NAME=\")[^\"]+(?=\")" /etc/os-release)"
-    if [ "${LIN_DISTRO_NAME}" == "CentOS Linux" ]; then
-        LIB_INSTALL_DIR="/usr/lib"
-    elif [[ "${LIN_DISTRO_NAME}" =~ Yocto ]]; then
-        LIB_INSTALL_DIR="/usr/lib"
-    fi
+    # write prefix installation directory
+    local INSTALL_PREFIX="/usr/local"
+    local LIN_DISTRO_ID="$(grep ^ID= /etc/os-release | cut -d'=' -f2)"
+    case "$LIN_DISTRO_ID" in
+        *rhel*|*centos*|*fedora*)
+        INSTALL_PREFIX="/usr"
+        ;;
+        *ubuntu*|*debian*)
+        INSTALL_PREFIX="/usr/local"
+        ;;
+    esac
+
+    local BIN_INSTALL_DIR="${INSTALL_PREFIX}/bin"
+    local LIB_INSTALL_DIR="${INSTALL_PREFIX}/lib"
+
+    local bin_dir
+    bin_dir="$(echo "${BIN_INSTALL_DIR}" | sed "s/\//@/g")"
+    sed -i.bak "s/SCAN_BIN_INSTALL_DIR/${bin_dir}/g" ${TMP_MAKE_FILE}
+
     local lib_dir
     lib_dir="$(echo "${LIB_INSTALL_DIR}" | sed "s/\//@/g")"
     sed -i.bak "s/SCAN_LIB_INSTALL_DIR/${lib_dir}/g" ${TMP_MAKE_FILE}

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -345,7 +345,7 @@ The binaries will be installed in the following directories on the target:
 
 - Executables
 
-  ``/usr/local/bin``
+  ``/usr/local/bin`` or ``/usr/bin``
 
 - Descriptor files
 


### PR DESCRIPTION
Depending on the distro in which MDIS is installed, the PATH environment variable and ldconfig may be different so try and match what the default installation path should be for each distro automatically.