### PR TITLE
Fix compilation after -isystem option removal on kernel

### DIFF
--- a/MDISforLinux/INCLUDE/NATIVE/MEN/oss_os.h
+++ b/MDISforLinux/INCLUDE/NATIVE/MEN/oss_os.h
@@ -33,7 +33,6 @@
 #endif
 
 #include <linux/types.h>
-#include <stdarg.h> /* for va_list */
 
 /*-----------------------------------------+
 |  DEFINES & CONST                         |
@@ -44,6 +43,12 @@
 #ifdef __KERNEL__
 #include <linux/timer.h>
 #include <linux/spinlock.h>
+#include <linux/version.h>
+#if LINUX_VERSION_CODE > KERNEL_VERSION(5,15,0)
+#include <linux/stdarg.h> /* for va_list */
+#else
+#include <stdarg.h> /* for va_list */
+#endif
 
 #define OSS_HAS_UNASSIGN_RESOURCES /* flag for oss.h  */
 
@@ -203,6 +208,8 @@ extern int32  OSS_Exit( OSS_HANDLE **ossP );
 
 
 #else /* NOT KERNEL */
+#include <stdarg.h>
+
 typedef void OSS_HANDLE;
 typedef void OSS_ALARM_HANDLE;
 typedef void OSS_SIG_HANDLE;

--- a/MDISforLinux/INCLUDE/NATIVE/MEN/oss_os.h
+++ b/MDISforLinux/INCLUDE/NATIVE/MEN/oss_os.h
@@ -44,11 +44,19 @@
 #include <linux/timer.h>
 #include <linux/spinlock.h>
 #include <linux/version.h>
+
 #if LINUX_VERSION_CODE > KERNEL_VERSION(5,15,0)
 #include <linux/stdarg.h> /* for va_list */
 #else
+// RHEL specific changes
+#if defined(RHEL_RELEASE_CODE) && defined(RHEL_RELEASE_VERSION)
+#if RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9,1)
+#include <linux/stdarg.h> /* for va_list */
+#endif // RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9,1)
+#else
 #include <stdarg.h> /* for va_list */
-#endif
+#endif // defined(RHEL_RELEASE_CODE) && defined(RHEL_RELEASE_VERSION)
+#endif // LINUX_VERSION_CODE > KERNEL_VERSION(5,15,0)
 
 #define OSS_HAS_UNASSIGN_RESOURCES /* flag for oss.h  */
 


### PR DESCRIPTION
The Linux kernel has removed the -isystem compiler option to avoid accidental inclusion of undesireable headers from version 5.16. This fixes the compilation error an uses the headers included in the kernel tree.