### PR TITLE
vme4l: fix null pointer dereference when exitin module

### DIFF
--- a/MDISforLinux/DRIVERS/VME_16Z002/vme4l-core.c
+++ b/MDISforLinux/DRIVERS/VME_16Z002/vme4l-core.c
@@ -395,10 +395,14 @@ static int do_free_adrswin(VME4L_ADRSWIN *win, bool checkUseCount)
 	}
 
 	if(!checkUseCount || lastReference) {
-		rv = G_bDrv->releaseAddrWindow(G_bHandle,
-			win->spc, win->vmeAddr, win->size,
-			win->flags, win->bDrvData);
-
+		if (G_bDrv) {
+			rv = G_bDrv->releaseAddrWindow(G_bHandle,
+						       win->spc,
+						       win->vmeAddr,
+						       win->size,
+						       win->flags,
+						       win->bDrvData);
+		}
 		if( !rv ) {
 			list_del(&win->node);
 


### PR DESCRIPTION
vme4l-core module is trying to access a null pointer on exit with vme4l_cleanup_module(). This G_bDrv pointer is assigned to NULL previously with vme4l_unregister_bridge_driver().

Fix this by protecting the callback function G_bDrv->releaseAddrWindow as this may get called via an ioctl and not just when doing the module cleanup.

fixes: 22d760a642f41d0da7fd3345ddffb279f9537de7
("vme4l-core.c: applied patch from M.Suminski to release address windows")