### PR TITLE
Pull Request to disable compilation vme modules kernel 6.1

### DIFF
--- a/MDISforLinux/DRIVERS/VME_16Z002/vme4l-tsi148.c
+++ b/MDISforLinux/DRIVERS/VME_16Z002/vme4l-tsi148.c
@@ -25,10 +25,15 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 #include <linux/version.h>
 #include <linux/module.h>
 #include <linux/kernel.h> /* printk() */
 #include <linux/pci.h>
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,1,0)
+#error This module is not supported by MDIS for Kernel version 6.1 and above.
+#else // LINUX_VERSION_CODE >= KERNEL_VERSION(6,1,0)
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,26)
  #include <asm/semaphore.h>
@@ -2680,3 +2685,4 @@ MODULE_LICENSE("GPL");
 #ifdef MAK_REVISION
 MODULE_VERSION(MENT_XSTR(MAK_REVISION));
 #endif
+#endif //LINUX_VERSION_CODE >= KERNEL_VERSION(6,1,0)


### PR DESCRIPTION
Second part of the changeset to trigger an error in the VME modules compile against kernel version 6.1 and above.

The PR is intended to be a work around to fix https://github.com/MEN-Mikro-Elektronik/13MD05-90/issues/283