### PR TITLE
Pull Request to use tag date instead of last commit date in STAMPED_VERSION

### DIFF
--- a/INSTALL.sh
+++ b/INSTALL.sh
@@ -348,7 +348,15 @@ make_history_script() {
             git log > "${MDIS_HISTORY_PATH}/${var2}_history.txt"
             git remote -v > "${MDIS_HISTORY_PATH}/${var2}_url.txt"
             gitRevision=$(git describe --dirty --long --tags --always)
-            gitDate=$(git --no-pager show -s --date=short --format=format:"%cd%n")
+            gitLatestTag=$(git describe --tags)
+            # First, try to get the date of the latest tag.
+            gitTagDate=$(git for-each-ref --format='%(taggerdate:short) | %(tag)' | grep -m1 ${gitLatestTag} | awk '{print $1}')
+            # If tag date is found, just get it, use the fallback method otherwise
+            if [ ! -z ${gitTagDate} ]; then
+                gitDate=${gitTagDate}
+            else
+                gitDate=$(git --no-pager show -s --date=short --format=format:"%cd%n")
+            fi
             echo "${gitRevision}_${gitDate}" > "${MDIS_HISTORY_PATH}/${var2}_version.txt"
             git describe --exact-match --tags "$(git rev-parse --verify HEAD)" &> "${MDIS_HISTORY_PATH}/${var2}_tag.txt"
             cd "${MDIS_REPO_DIR}" || { echo "cannot change directory into: ${MDIS_REPO_DIR}"; exit 1; }


### PR DESCRIPTION
Currently, the STAMPED_VERSION that is printed in each submodule's Makefile is got from the latest commit date, however, if more than one tag point to the same commit hash, the STAMPED_VERSION will be always the same.

The changes proposed here just get the tag date so every time a new tag is created, the STAMPED_VERSION will change, even if it points to the same commit.