### PR TITLE
Drop support for 13Z051-06 component

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -100,9 +100,6 @@
 [submodule "13Z047-06"]
 	path = 13Z047-06
 	url = ../13Z047-06.git
-[submodule "13Z051-06"]
-	path = 13Z051-06
-	url = ../13Z051-06.git
 [submodule "13Z055-90"]
 	path = 13Z055-90
 	url = ../13Z055-90.git


### PR DESCRIPTION
Z051 Ip core is only used on a custom designedf multifunction board F401. This IP core and its driver are fairly unstable, leading to pci bus corruption. So drop support for now.